### PR TITLE
BECs Camera Class

### DIFF
--- a/BECS-Assets/assets/basic_framebuffer.frag
+++ b/BECS-Assets/assets/basic_framebuffer.frag
@@ -1,0 +1,10 @@
+#version 330 core
+
+out vec4 fragColor;
+in vec2 TexCoords;
+uniform sampler2D fbo_texture;
+
+void main()
+{ 
+	fragColor = texture2D(fbo_texture, TexCoords);
+}

--- a/BECS-Core/src/com/botifier/becs/Game.java
+++ b/BECS-Core/src/com/botifier/becs/Game.java
@@ -435,6 +435,15 @@ public abstract class Game {
 		eventManager.registerListener(wl);
 		worldListenerId.set(wl.getOwner());
 
+		Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+			
+			@Override
+			public void uncaughtException(Thread t, Throwable e) {
+				System.out.println(String.format("Thread %s threw an Exception: %s", t.getName(), e.getMessage()));
+				e.printStackTrace();
+			}
+		});
+		
 		init();
 
 		input = new Input(window.getId());
@@ -945,7 +954,7 @@ public abstract class Game {
 															   getWidth() * getRenderer().getZoom(),
 															   getHeight() * getRenderer().getZoom());
 			WorldState ws = new WorldState(camera.toPolygon(), false); //Creates a WorldState 
-
+			getRenderer().refreshWindow();
 			draw(getRenderer(), ws, camera, alpha.get()); //Runs draw functions
 			if (autoDrawBatch) {
 				getRenderer().getAutoBatcher().draw(getRenderer()); //Automatically draws information in the AutoBatcher

--- a/BECS-Core/src/com/botifier/becs/entity/Entity.java
+++ b/BECS-Core/src/com/botifier/becs/entity/Entity.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 
 import org.joml.Vector2f;
 
+import com.botifier.becs.Game;
+import com.botifier.becs.events.EntityDeathEvent;
 import com.botifier.becs.graphics.Renderer;
 import com.botifier.becs.graphics.images.Image;
 import com.botifier.becs.util.SpatialEntityMap;
@@ -62,7 +64,7 @@ public class Entity implements Comparable<Entity>, Cloneable{
 	/**
 	 * Whether or not this entity's sprites should be automatically batched
 	 */
-	private boolean autoBatch = false;
+	private boolean autoBatch = true;
 
 	/**
 	 * Whether or not the Entity is a ruse
@@ -108,11 +110,15 @@ public class Entity implements Comparable<Entity>, Cloneable{
 	 */
 	public void destroy() {
 		dead = true;
+
+		Game.getCurrent().getEventManager().executeEvent(new EntityDeathEvent(this.falseClone()));
+		
 		if (entities.contains(uuid))
 			entities.remove(uuid);
 		for (String s : components.keySet()) {
 			removeComponent(s);
 		}
+		
 	}
 
 	/**
@@ -422,9 +428,8 @@ public class Entity implements Comparable<Entity>, Cloneable{
 	 * @param e Entity To add
 	 */
 	public static void addEntity(Entity e) {
-		e.init();
-
 		if (!entities.contains(e.getUUID())) {
+			e.init();
 			entities.put(e.getUUID(), e);
 		}
 	}

--- a/BECS-Core/src/com/botifier/becs/entity/EntityComponent.java
+++ b/BECS-Core/src/com/botifier/becs/entity/EntityComponent.java
@@ -112,6 +112,9 @@ public class EntityComponent<T> implements Cloneable {
 		return owner != null ? owner.getUUID() : null;
 	}
 
+	public Class<?> getDataType() {
+		return type;
+	}
 	@Override
 	public EntityComponent<T> clone() {
 		return new EntityComponent<T>(name, owner, information.get());

--- a/BECS-Core/src/com/botifier/becs/entity/EntityVector2fComponent.java
+++ b/BECS-Core/src/com/botifier/becs/entity/EntityVector2fComponent.java
@@ -3,7 +3,6 @@ package com.botifier.becs.entity;
 import java.util.function.UnaryOperator;
 
 import org.joml.Vector2f;
-import org.joml.Vector2fc;
 
 import com.botifier.becs.Game;
 import com.botifier.becs.events.EntityComponentUpdatedEvent;

--- a/BECS-Core/src/com/botifier/becs/events/EntityDeathEvent.java
+++ b/BECS-Core/src/com/botifier/becs/events/EntityDeathEvent.java
@@ -1,0 +1,16 @@
+package com.botifier.becs.events;
+
+import com.botifier.becs.entity.Entity;
+import com.botifier.becs.util.events.Event;
+
+public class EntityDeathEvent extends Event {
+	private final Entity e;
+	
+	public EntityDeathEvent(Entity e) {
+		this.e = e;
+	}
+	
+	public Entity getEntity() {
+		return e;
+	}
+}

--- a/BECS-Core/src/com/botifier/becs/events/listeners/CameraListener.java
+++ b/BECS-Core/src/com/botifier/becs/events/listeners/CameraListener.java
@@ -1,0 +1,35 @@
+package com.botifier.becs.events.listeners;
+
+import java.util.UUID;
+
+import org.joml.Vector2f;
+
+import com.botifier.becs.Game;
+import com.botifier.becs.events.EntityComponentRemovedEvent;
+import com.botifier.becs.events.EntityComponentUpdatedEvent;
+import com.botifier.becs.util.annotations.EventHandler;
+import com.botifier.becs.util.events.EventListener;
+import com.botifier.becs.util.render.Camera;
+
+public class CameraListener extends EventListener {
+
+	private Camera c;
+	
+	public CameraListener(Camera c, UUID entity) {
+		super(entity);
+		this.c = c;
+	}
+	
+	@EventHandler(event = EntityComponentRemovedEvent.class, origin = "Position")
+	public void onPositionComponentRemoved(EntityComponentRemovedEvent<Vector2f> e) {
+		c.setFollowEntity(null);
+		Game.getCurrent().getEventManager().unregisterListener(this);
+	}
+	
+
+	@EventHandler(event = EntityComponentUpdatedEvent.class, origin = "Position")
+	public void onMove(EntityComponentUpdatedEvent<Vector2f> e) {
+		c.setCenter(e.getNewValue());
+	}
+	
+}

--- a/BECS-Core/src/com/botifier/becs/events/listeners/WorldListener.java
+++ b/BECS-Core/src/com/botifier/becs/events/listeners/WorldListener.java
@@ -16,7 +16,7 @@ public class WorldListener extends EventListener {
 	public void onComponentAdded(EntityComponentAddedEvent<Shape> e) {
 		Entity en = e.getTarget();
 		
-		if (en.hasComponent("Position")) {
+		if (en.hasComponent("Position") && !Entity.spatialMap().contains(en)) {
 			EntityComponent<Shape> s = e.getComponent();
 			EntityComponent<Vector2f> pC = en.getComponent("Position");
 			Vector2f p = pC.get();
@@ -26,6 +26,41 @@ public class WorldListener extends EventListener {
 			e.getComponent().set(sh);
 
 			Entity.spatialMap().addEntity(en);
+		}
+	}
+	
+	@EventHandler(event = EntityComponentAddedEvent.class, origin = "Position")
+	public void onPositionAdded(EntityComponentAddedEvent<Vector2f> e) {
+		Entity en = e.getTarget();
+		
+		if (en.hasComponent("CollisionShape") && !Entity.spatialMap().contains(en)) {
+			EntityComponent<Shape> s = en.getComponent("CollisionShape");
+			EntityComponent<Vector2f> pC = e.getComponent();
+			Vector2f p = pC.get();
+
+			Shape sh = s.get();
+			sh.setCenter(p.x, p.y);
+			s.set(sh);
+
+			Entity.spatialMap().addEntity(en);
+		}
+	}
+	
+	@EventHandler(event = EntityComponentRemovedEvent.class, origin = "Position")
+	public void onPositionRemoved(EntityComponentRemovedEvent<Vector2f> e) {
+		Entity en = e.getTarget();
+		
+		if (Entity.spatialMap().contains(en)) {
+			Entity.spatialMap().removeEntity(en);
+		}
+	}
+	
+	@EventHandler(event = EntityComponentRemovedEvent.class, origin = "CollisionShape")
+	public void onShapeRemoved(EntityComponentRemovedEvent<Shape> e) {
+		Entity en = e.getTarget();
+		
+		if (Entity.spatialMap().contains(en)) {
+			Entity.spatialMap().removeEntity(en);
 		}
 	}
 	

--- a/BECS-Core/src/com/botifier/becs/graphics/AutoBatcher.java
+++ b/BECS-Core/src/com/botifier/becs/graphics/AutoBatcher.java
@@ -4,11 +4,6 @@ import java.awt.Color;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.joml.Vector2f;
-import org.lwjgl.opengl.GL;
-import org.lwjgl.opengl.GLCapabilities;
-
-import com.botifier.becs.Game;
 import com.botifier.becs.graphics.images.Image;
 import com.botifier.becs.graphics.images.Texture;
 import com.botifier.becs.util.shapes.Shape;

--- a/BECS-Core/src/com/botifier/becs/graphics/Renderer.java
+++ b/BECS-Core/src/com/botifier/becs/graphics/Renderer.java
@@ -3,7 +3,6 @@ package com.botifier.becs.graphics;
 import static org.lwjgl.opengl.GL11.GL_BLEND;
 import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
 import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
-import static org.lwjgl.opengl.GL11.GL_LINE_SMOOTH;
 import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
 import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
 import static org.lwjgl.opengl.GL11.GL_TEXTURE_2D;
@@ -711,6 +710,7 @@ public class Renderer {
 		int width = Game.getCurrent().getWidth(), height = Game.getCurrent().getHeight();
 
 		projection = new Matrix4f().ortho(0, width * getZoom(), 0, height * getZoom(), 100, -100);
+		projection.translate(center);
 		setProjectionMatrix(program, projection);
 		GL11.glViewport(0, 0, Game.getCurrent().getWidth(), Game.getCurrent().getHeight());
 	}
@@ -736,7 +736,7 @@ public class Renderer {
 	public void tempResetZoom() {
 
 		int width = Game.getCurrent().getWidth(), height = Game.getCurrent().getHeight();
-		useZoom = false;
+		//useZoom = false;
 		Matrix4f projection = new Matrix4f().ortho2D(0, width, 0, height);
 		projection.setTranslation(center);
 		updateProjectionMatrix(program, projection);
@@ -752,6 +752,21 @@ public class Renderer {
 		int width = Game.getCurrent().getWidth(), height = Game.getCurrent().getHeight();
 
 		Matrix4f projection = new Matrix4f().ortho2D(0, width * getZoom(), 0, height * getZoom());
+
+		updateProjectionMatrix(program, projection);
+	}
+	
+	/**
+	 * Temporarily moves the camera
+	 * @param pos Vector2f Position to move to
+	 * @param offset Vector2f Offset
+	 */
+	public void tempSetCenter(Vector2f pos, Vector2f offset) {
+		int width = Game.getCurrent().getWidth(), height = Game.getCurrent().getHeight();
+
+		Matrix4f projection = new Matrix4f().ortho2D(0, width * getZoom(), 0, height * getZoom());
+		Vector3f center = new Vector3f(-pos.x + (width * getZoom()) / 2 + offset.x, -pos.y + (height * getZoom()) / 2 + offset.y, 0);
+		projection.translate(center);
 
 		updateProjectionMatrix(program, projection);
 	}

--- a/BECS-Core/src/com/botifier/becs/graphics/images/Image.java
+++ b/BECS-Core/src/com/botifier/becs/graphics/images/Image.java
@@ -189,7 +189,7 @@ public class Image {
 	 * @param y float Y
 	 */
 	public void draw(Renderer renderer, float x, float y) {
-		draw(renderer,x,y, z, c, ResourceManager.getShader(sp));
+		draw(renderer,x,y, z, c, ResourceManager.getShaderProgram(sp));
 	}
 
 	/**
@@ -201,7 +201,7 @@ public class Image {
 	 * @param c Color Color filter
 	 */
 	public void draw(Renderer renderer, float x, float y, float z, Color c) {
-		draw(renderer,x,y, z,c, ResourceManager.getShader(sp));
+		draw(renderer,x,y, z,c, ResourceManager.getShaderProgram(sp));
 	}
 
 	/**
@@ -470,7 +470,7 @@ public class Image {
 	 */
 	public ShaderProgram getShaderProgram() {
 		if (buffer == null && sp != null)
-			buffer = ResourceManager.getShader(sp);
+			buffer = ResourceManager.getShaderProgram(sp);
 		return buffer;
 	}
 

--- a/BECS-Core/src/com/botifier/becs/util/ResourceManager.java
+++ b/BECS-Core/src/com/botifier/becs/util/ResourceManager.java
@@ -2,8 +2,10 @@ package com.botifier.becs.util;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import com.botifier.becs.graphics.images.Texture;
+import com.botifier.becs.graphics.shader.Shader;
 import com.botifier.becs.graphics.shader.ShaderProgram;
 import com.botifier.becs.sound.Sound;
 
@@ -18,33 +20,103 @@ public class ResourceManager {
 
 	private final static Map<String, Texture> images = new ConcurrentHashMap<String, Texture>();
 	private final static Map<String, Sound> sounds = new ConcurrentHashMap<String, Sound>();
-	private final static Map<String, ShaderProgram> shaders = new ConcurrentHashMap<String, ShaderProgram>();
+	private final static Map<String, ShaderProgram> shaderPrograms = new ConcurrentHashMap<String, ShaderProgram>();
+	private final static Map<String, Shader> shaders = new ConcurrentHashMap<String, Shader>();
 	
-	public static void loadTexture(String name, String loc) {
-		images.put(name.toLowerCase(), Texture.loadTexture(loc));
+	public static Texture loadTexture(String name, String loc) {
+		return images.put(name.toLowerCase(), Texture.loadTexture(loc));
 	}
 	
-	public static void putTexture(String name, Texture t) {
-		images.put(name.toLowerCase(), t);
+	public static Texture loadOrGetTexture(String name, String loc) {
+		return images.computeIfAbsent(name.toLowerCase(), t -> Texture.loadTexture(loc));
+	}
+	
+	public static Texture putTexture(String name, Texture t) {
+		return images.put(name.toLowerCase(), t);
 	}
 	
 	public static Texture getTexture(String name) {
 		return images.getOrDefault(name.toLowerCase(), null);
 	}
 	
-	public static void putSound(String name, Sound s) {
-		sounds.put(name.toLowerCase(), s);
+	public static Texture getOrPutTexture(String name, Function<? super String, ? extends Texture> consumer) {
+		return images.computeIfAbsent(name.toLowerCase(), consumer);
+	}
+	
+	public static Sound loadSound(String name, String loc) {
+		return sounds.put(name.toLowerCase(), Sound.createSound(loc, false, false));
+	}
+	
+	public static Sound loadSound(String name, String loc, boolean loop, boolean relative) {
+		return sounds.put(name.toLowerCase(), Sound.createSound(loc, loop, relative));
+	}
+	
+	public static Sound loadOrGetSound(String name, String loc) {
+		return loadOrGetSound(name.toLowerCase(), loc, false, false);
+	}
+	
+	public static Sound loadOrGetSound(String name, String loc, boolean loop, boolean relative) {
+		return sounds.computeIfAbsent(name.toLowerCase(), s -> Sound.createSound(loc, loop, relative));
+	}
+	
+	public static Sound putSound(String name, Sound s) {
+		return sounds.put(name.toLowerCase(), s);
 	}
 	
 	public static Sound getSound(String name) {
 		return sounds.getOrDefault(name.toLowerCase(), null).copy();
 	}
 	
-	public static void putShaderProgram(String name, ShaderProgram sp) {
-		shaders.put(name.toLowerCase(), sp);
+	public static Sound getOrPutSound(String name, Function<? super String, ? extends Sound> consumer) {
+		return sounds.computeIfAbsent(name, consumer);
 	}
 	
-	public static ShaderProgram getShader(String name) {
+	public static ShaderProgram putShaderProgram(String name, ShaderProgram sp) {
+		return shaderPrograms.put(name.toLowerCase(), sp);
+	}
+	
+	public static ShaderProgram getShaderProgram(String name) {
+		return shaderPrograms.getOrDefault(name.toLowerCase(), null);
+	}
+	
+	public static ShaderProgram getOrPutShaderProgram(String name, Function<? super String, ? extends ShaderProgram> consumer) {
+		return shaderPrograms.computeIfAbsent(name.toLowerCase(), consumer);
+	}
+	
+	
+	public static Shader loadOrGetShader(String name, int shaderType, String location) {
+		return shaders.computeIfAbsent(name, s -> Shader.loadShader(shaderType, location));
+	}
+	
+	public static Shader loadShader(String name, int shaderType, String location) {
+		return shaders.put(name, Shader.loadShader(shaderType, location));
+	}
+	
+	public static Shader putShader(String name, Shader s) {
+		return shaders.put(name.toLowerCase(), s);
+	}
+	
+	public static Shader getShader(String name) {
 		return shaders.getOrDefault(name.toLowerCase(), null);
+	}
+	
+	public static Shader getOrPutShader(String name, Function<? super String, ? extends Shader> consumer) {
+		return shaders.computeIfAbsent(name.toLowerCase(), consumer);
+	}
+	
+	public static boolean hasShader(String name) {
+		return shaderPrograms.containsKey(name.toLowerCase());
+	}
+	
+	public static boolean hasShaderProgram(String name) {
+		return shaderPrograms.containsKey(name.toLowerCase());
+	}
+	
+	public static boolean hasTexture(String name) {
+		return images.containsKey(name.toLowerCase());
+	}
+	
+	public static boolean hasSound(String name) {
+		return images.containsKey(name);
 	}
 }

--- a/BECS-Core/src/com/botifier/becs/util/render/Camera.java
+++ b/BECS-Core/src/com/botifier/becs/util/render/Camera.java
@@ -1,0 +1,273 @@
+package com.botifier.becs.util.render;
+
+import static org.lwjgl.opengl.GL20.GL_FRAGMENT_SHADER;
+import static org.lwjgl.opengl.GL20.GL_VERTEX_SHADER;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.joml.Vector2f;
+import org.joml.Vector3f;
+import com.botifier.becs.Game;
+import com.botifier.becs.entity.Entity;
+import com.botifier.becs.events.listeners.CameraListener;
+import com.botifier.becs.graphics.FBO;
+import com.botifier.becs.graphics.Renderer;
+import com.botifier.becs.graphics.shader.Shader;
+import com.botifier.becs.graphics.shader.ShaderProgram;
+import com.botifier.becs.util.ResourceManager;
+import com.botifier.becs.util.SpatialEntityMap;
+import com.botifier.becs.util.SpatialPolygonHolder;
+import com.botifier.becs.util.shapes.RotatableRectangle;
+
+/**
+ * Camera class
+ * @author Botifier
+ */
+public class Camera {
+	
+	/**
+	 * Game that this camera exists in
+	 */
+	private Game game;
+	
+	/**
+	 * Rectangle that represents the camera
+	 */
+	private RotatableRectangle camera;
+	
+	/**
+	 * The map to query for entity culling
+	 */
+	private SpatialEntityMap sem = Entity.spatialMap();
+	
+	/**
+	 * Polygon cache for entity querying
+	 */
+	private SpatialPolygonHolder cache = null;
+	
+	/**
+	 * Target entity to follow
+	 */
+	private Entity target = null;
+	
+	/**
+	 * Event listener tied to the followed entity 
+	 */
+	private CameraListener cl = null;
+	
+	/**
+	 * Temporary storage for the original center of the camera
+	 */
+	private Vector3f oldCenter = null;
+	
+	/**
+	 * Frame buffer that the camera is drawn to
+	 */
+	private FBO cameraBuffer = null;
+	
+	/**
+	 * Whether or not the camera has resize or moved
+	 */
+	private boolean changed = false;
+	
+	
+	/**
+	 * Camera constructor
+	 * @param g Game To use
+	 * @param center Vector2f Center of the camera
+	 * @param width float Width of the camera
+	 * @param height float Height of the camera
+	 */
+	public Camera(Game g, Vector2f center, float width, float height) {
+		this.game = g;
+		this.camera = new RotatableRectangle(center, width, height);
+		
+		ShaderProgram shp = ResourceManager.getOrPutShaderProgram("CameraShaderProgram", s -> {
+			ShaderProgram sp = new ShaderProgram();
+			Shader v = ResourceManager.loadOrGetShader("CameraVertex", GL_VERTEX_SHADER, "framebuffer.vert");
+			Shader f = ResourceManager.loadOrGetShader("CameraFragment", GL_FRAGMENT_SHADER, "basic_framebuffer.frag");
+			
+			sp.attachShader(v);
+			sp.attachShader(f);
+			sp.bindFragmentDataLocation(0, "fragColor");
+			sp.link();
+			return sp;
+		});
+		this.cameraBuffer = new FBO().init(shp);
+		this.cameraBuffer.resize((int) width, (int) height);
+	}
+	
+	
+	/**
+	 * Begin drawing to the camera's frame buffer
+	 * @param r Renderer To use
+	 */
+	public void beginDrawing(Renderer r) {
+		this.oldCenter = r.getCameraCenter();
+		r.setCameraCenter(getCenter());
+		this.cameraBuffer.bind();
+		this.cameraBuffer.clearTexture();
+
+	}
+	
+	/**
+	 * Finish drawing to the camera's frame buffer
+	 * @param r Renderer To use
+	 */
+	public void endDrawing(Renderer r) {
+		this.cameraBuffer.unbind();
+		
+		this.cameraBuffer.draw(r);
+		r.setCameraCenter(new Vector2f(oldCenter));
+		oldCenter = null;
+	}
+	
+	/**
+	 * Draws entities within the camera along with anything that is in the auto batcher.
+	 * @param r Renderer To use
+	 */
+	public void draw(Renderer r) {
+		beginDrawing(r);
+		queryVisible().forEach(e -> {
+	  		e.draw(r);
+		});
+		r.getAutoBatcher().draw(r);
+		endDrawing(r);
+	}
+	
+	/**
+	 * Queries the current SpatialEntityMap for visible entities
+	 * @return Set\<Entity\> Valid entities 
+	 */
+	public Set<Entity> queryVisible() {
+		if (this.sem == null) 
+			return ConcurrentHashMap.newKeySet();
+		
+		if (this.cache == null || changed) {
+			this.cache = this.getSpatialEntityMap().gridifyPolygon(camera.toPolygon());
+			changed = false;
+		}
+		
+		Set<Entity> entities = getSpatialEntityMap().getEntitiesIn(null, false, cache.getHashes());
+		
+		return entities;
+	}
+	
+	/**
+	 * Gets the currently used SpatialEntityMap
+	 * @return SpatialEntityMap Current
+	 */
+	public SpatialEntityMap getSpatialEntityMap() {
+		return this.sem;
+	}
+	
+	/**
+	 * Starts following the target entity
+	 * Unfollows the last one if valid
+	 * @param e Entity To follow
+	 */
+	public void setFollowEntity(Entity e) {
+		if (e == null) {
+			this.game.getEventManager().unregisterListener(cl);
+			this.cl = null;
+			return;
+		}
+		if (!e.hasComponent("Position"))
+			return;
+		if (e != null && this.cl != null) {
+			this.game.getEventManager().unregisterListener(cl);
+			this.cl = null;
+		}
+		this.target = e;
+		this.cl = new CameraListener(this, e.getUUID());
+		this.game.getEventManager().registerListener(cl);
+	}
+	
+	/**
+	 * Sets the current SpatialEntityMap
+	 * @param sem SpatialEntityMap To use
+	 */
+	public void setSpatialMap(SpatialEntityMap sem) {
+		this.sem = sem;
+	}
+	
+	/**
+	 * Sets the camera's center
+	 * @param center Vector2f The center
+	 */
+	public void setCenter(Vector2f center) {
+		if (center == null)
+			throw new IllegalArgumentException("Center cannot be null");
+		this.changed = true;
+		this.camera.setCenter(center);
+	}
+	
+	/**
+	 * Sets the camera's width
+	 * Cannot be zero or less
+	 * @param width float To use
+	 */
+	public void setWidth(float width) {
+		if (width <= 0)
+			throw new IllegalArgumentException("Width cannot be zero or less");
+		this.changed = true;
+		this.camera.setWidth(width);
+
+		this.cameraBuffer.resize((int) this.camera.getWidth(), (int) this.camera.getHeight());
+	}
+	
+	/**
+	 * Sets the camera's height
+	 * Cannot be zero or less
+	 * @param height float To use
+	 */
+	public void setHeight(float height) {
+		if (height <= 0)
+			throw new IllegalArgumentException("Height cannot be zero or less.");
+		this.changed = true;
+		this.camera.setHeight(height);
+		this.cameraBuffer.resize((int) this.camera.getWidth(), (int) this.camera.getHeight());
+	}
+	
+	/**
+	 * Gets the entity that this camera is following
+	 * @return Entity The target
+	 */
+	public Entity getFollowing() {
+		return target;
+	}
+	
+	/**
+	 * Gets the center of the camera
+	 * @return Vector2f The center of the camera
+	 */
+	public Vector2f getCenter() {
+		return this.camera.getCenter();
+	}
+	
+	/**
+	 * Gets the RotatableRectangle that represents the camera
+	 * @return RotatableRectangle The rectangle
+	 */
+	public RotatableRectangle getRectangle() {
+		return camera;
+	}
+	
+	/**
+	 * Gets the camera's width
+	 * @return float The width
+	 */
+	public float getWidth() {
+		return this.camera.getWidth();
+	}
+	
+	/**
+	 * Gets the camera's height
+	 * @return float The height
+	 */
+	public float getHeight() {
+		return this.camera.getHeight();
+	}
+	
+}

--- a/BECS-Tests/src/com/botifier/becs/tests/HelloWorld.java
+++ b/BECS-Tests/src/com/botifier/becs/tests/HelloWorld.java
@@ -2,6 +2,8 @@ package com.botifier.becs.tests;
 
 
 import java.awt.Color;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +39,7 @@ import com.botifier.becs.util.CollisionUtil.PolygonOutput;
 import com.botifier.becs.util.EntityRunnable;
 import com.botifier.becs.util.ParameterizedRunnable;
 import com.botifier.becs.util.SpatialEntityMap;
+import com.botifier.becs.util.render.Camera;
 import com.botifier.becs.util.shapes.Circle;
 import com.botifier.becs.util.shapes.Line;
 import com.botifier.becs.util.shapes.Polygon;
@@ -52,6 +55,7 @@ public class HelloWorld extends Game{
 	float dir = 1;
 	int size = 0;
 	boolean dire = false;
+	Entity wew;
 	Entity e;
 	Entity center;
 	AutoBatcher auto = new AutoBatcher();
@@ -64,9 +68,10 @@ public class HelloWorld extends Game{
 	Circle c;
 	Line temp;
 	ArrayList<Vector2f> previousLocs = new ArrayList<>();
+	Camera camera;
 
 	public HelloWorld() {
-		super("Hello World", 800, 800, false, true, true);
+		super("Hello World", 800, 800, true, true, false);
 	}
 
 	@Override
@@ -81,7 +86,7 @@ public class HelloWorld extends Game{
 
 		//System.out.println("Hello World! LWJGL Java "+Version.getVersion());
 
-		fbo = new FBO("framebuffer.vert", "framebuffer.frag").init();
+		//fbo = new FBO("framebuffer.vert", "framebuffer.frag").init();
 
 		i = new Image("Tile.png");
 		i.setScale(1f);
@@ -89,6 +94,12 @@ public class HelloWorld extends Game{
 		i2.setScale(0.5f);
 		//i2.setShaderProgram(sp);
 		i3 = new Image("WhitePixel.png");
+		
+		try {
+			i2.getTexture().write(new File("froggy.png"));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 
 
 		Sound so = Sound.createSound("sounds/alien_crow.wav", false, true);
@@ -149,7 +160,7 @@ public class HelloWorld extends Game{
 		}
 		for (int i = 0; i < 1; i++) {
 			final int localI = i;
-			Entity e2 = new Entity("Davy") {
+			wew = new Entity("Davy") {
 				@Override
 				public void init() {
 					float angle = (float) Math.toRadians(22.5f);
@@ -165,7 +176,7 @@ public class HelloWorld extends Game{
 					this.addComponent("Solid", true);
 				}
 			};
-			Entity.addEntity(e2);
+			Entity.addEntity(wew);
 		}
 		
 		IntStream.range(0, 10000).parallel().forEach(i -> {
@@ -240,8 +251,11 @@ public class HelloWorld extends Game{
 			temp = new Line(0, 0, 1, 1);
 		}
 
-
-		getRenderer().setZoom(4f);
+		
+		camera = new Camera(this, new Vector2f(0, 0), this.getWidth(), this.getHeight());
+		camera.setFollowEntity(center);
+		
+		getRenderer().setZoom(1f);
 		getRenderer().setCameraCenter(new Vector2f(0, 0));
 	}
 
@@ -271,20 +285,25 @@ public class HelloWorld extends Game{
 
 		//if (posComp.get().x <);
 
+		if (getInput().isKeyPressed(GLFW.GLFW_KEY_C)) {
+			wew.removeComponent("Position");
+		}
+		
 		setTitle("FPS: "+getTimer().getFPS()+", UPS: "+getTimer().getUPS());
 	}
 
 	@Override
 	public void draw(Renderer r, WorldState state, RotatableRectangle camera, float alpha) {
-
-		if (center != null) {
+		this.camera.draw(r);
+		
+		/*if (center != null) {
 			if (center.hasComponent("Position")) {
 				EntityComponent<Vector2f> posComp = center.getComponent("Position");
 				Vector2f v = posComp.get();
 				center.getComponent("Position").get();
-				//r.setCameraCenter(v);
+				r.setCameraCenter(v);
 			}
-		}
+		}*/
 
 		//i.drawBatched(getRenderer(), vs);
 
@@ -298,8 +317,8 @@ public class HelloWorld extends Game{
 
 		//i.drawBatched(r, vs);
 
-		SpatialEntityMap sem = state.sem;
-		Set<Entity> draw = sem.getEntitiesIn(camera.toPolygon());
+		//SpatialEntityMap sem = state.sem;
+		//Set<Entity> draw = sem.getEntitiesIn(camera.toPolygon());
 		//Image.WHITE_PIXEL.bind();
 		//r.begin();
 		/*
@@ -308,10 +327,10 @@ public class HelloWorld extends Game{
 			r.getAutoBatcher().add(Image.WHITE_PIXEL, rr, Color.yellow, -2);
 		});*/
 		//r.end();
-		draw.stream().forEach(e -> {
+		/*draw.stream().forEach(e -> {
 						  		e.setAutoBatch(true);
 						  		e.draw(r);
-						  });
+						  });*/
 
 		//renderDebugCollisions(r, sem);
 		/*


### PR DESCRIPTION
And related changes.
### Additions
- EntityDeathEvent
  - Will be used to remove CameraListener
  - Will allow for performing on death actions
- CameraListener
  - Attaches to an entity in order to follow it
- Camera
  - Utilizes a framebuffer so that specifics can be drawn to the camera
  - Can be assigned custom SpatialEntityMaps
  - Customer framebuffer shaders can be used by setting "CameraVertex" and "CameraFragment" before camera creation
  - Can use draw() to draw all valid entities or beginDraw() endDraw() for custom behavior
### Changes
- Entity
 - No longer directly handles the spatial map
 - Autobatching is now default behavior
 - addEntity no longer runs init() no matter what.
 - now throws an EntityDeathEvent on destruction
- Game
  - Added an uncaught exception handler to threads
- EntityComponentManager
  - Improved compatibility checks in order to avoid deadlocks
- EntityComponent
  - Class type of data can now be obtained 
- WorldListener
  - Now handles spatial map additions and removals
- FBO
  - Changes to init for more control
  - More documentation
  - Added uploadVBOData for custom fbo dimensions
- Renderer
  - Camera related fixes
- Texture
  - Added write method
  - Formatting fixes
- Image
  - Now pulls custom shader from ResourceManager  
- ResourceManager
  - Added more functionality like getOrPutTexture and loadOrGetSound